### PR TITLE
Improve MinIO Integration, Fix Routing & DBContext, and Stream Handling Issues

### DIFF
--- a/src/Media/Infrastructure/MediaDbContext.cs
+++ b/src/Media/Infrastructure/MediaDbContext.cs
@@ -25,7 +25,7 @@ public class UrlToken
 
     public required string ContentType { get; set; }
 
-    public DateTime ExpaireOn { get; set; }
+    public DateTime ExpireOn { get; set; }
 
     public int CountAccess { get; set; }
     public int LimitationAccess { get; set; }

--- a/src/Media/Program.cs
+++ b/src/Media/Program.cs
@@ -108,7 +108,10 @@ app.MapGet("/{token:guid:required}", async (
                                });
 
     await minioClient.GetObjectAsync(getObjectArgs);
-    return Results.File(memoryStream.ToArray()
+
+    memoryStream.Position = 0;
+
+    return Results.File(memoryStream
                         , contentType: foundToken.ContentType);
 
 });

--- a/src/Media/Program.cs
+++ b/src/Media/Program.cs
@@ -13,7 +13,7 @@ builder.Services.AddSwaggerGen();
 
 builder.Services.AddDbContext<MediaDbContext>(configure =>
 {
-    configure.UseInMemoryDatabase(Guid.NewGuid().ToString());
+    configure.UseInMemoryDatabase("MediaDb");
 });
 
 var endpoint = builder.Configuration["MinioStorage:MinioEndpoint"];

--- a/src/Media/Program.cs
+++ b/src/Media/Program.cs
@@ -85,13 +85,13 @@ app.MapPost("/{backet_name}/{catalog_id}", async (
 
 
 app.MapGet("/{token:guid:required}", async (
+    Guid token,
     MediaDbContext dbContext,
     IConfiguration configuration,
-    Guid Token,
     IMinioClient minioClient) =>
 {
 
-    var foundToken = await dbContext.Tokens.FirstOrDefaultAsync(x => x.Id == Token && x.ExpaireOn <= DateTime.UtcNow);
+    var foundToken = await dbContext.Tokens.FirstOrDefaultAsync(x => x.Id == token && x.ExpaireOn <= DateTime.UtcNow);
 
     if (foundToken is null)
         throw new InvalidOperationException();

--- a/src/Media/Program.cs
+++ b/src/Media/Program.cs
@@ -65,7 +65,7 @@ app.MapPost("/{backet_name}/{catalog_id}", async (
             BacketName = backetName,
             ObjectName = file.FileName,
             ContentType = file.ContentType,
-            ExpaireOn = DateTime.UtcNow.AddMinutes(10),
+            ExpireOn = DateTime.UtcNow.AddMinutes(10),
             Id = Guid.NewGuid()
         };
 
@@ -91,7 +91,7 @@ app.MapGet("/{token:guid:required}", async (
     IMinioClient minioClient) =>
 {
 
-    var foundToken = await dbContext.Tokens.FirstOrDefaultAsync(x => x.Id == token && x.ExpaireOn <= DateTime.UtcNow);
+    var foundToken = await dbContext.Tokens.FirstOrDefaultAsync(x => x.Id == token && x.ExpireOn >= DateTime.UtcNow);
 
     if (foundToken is null)
         throw new InvalidOperationException();


### PR DESCRIPTION
This pull request introduces several improvements and fixes:

- Dependency Injection for MinIO: MinIO is now available through DI, improving the code structure and flexibility.
- Routing Parameter Case Fix: Corrected the routing parameter case issue in the `Get` endpoint, ensuring proper Swagger functionality.
- Fixed In-Memory DB Context: The in-memory DbContext now uses a fixed database name, allowing data to persist across both endpoints during testing.
- Stream Handling Improvement: Resolved an issue with the stream position by resetting the `MemoryStream `position to 0 after copying data from MinIO. This prevents `Content-Length` mismatch errors in responses.
- Token Expiration Condition Fix: Fixed a logic issue where the expiration check used `<=` instead of `>=`, now ensuring tokens are valid if they haven't expired.