### PR TITLE
Remove memory string and write to response body directly

### DIFF
--- a/src/Media/Infrastructure/MediaDbContext.cs
+++ b/src/Media/Infrastructure/MediaDbContext.cs
@@ -19,7 +19,7 @@ public class UrlToken
 {
     public Guid Id { get; set; }
 
-    public required string BacketName { get; set; }
+    public required string BucketName { get; set; }
 
     public required string ObjectName { get; set; }
 


### PR DESCRIPTION
Changes list:
- Remove memory string and write file to response body directly
- Add missing dbContext.SaveChangesAsync()
- Remove unused parameters
- Fix typos